### PR TITLE
Add support for aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   outputs = { self, nixpkgs }:
     let
-      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" "aarch64-darwin" ];
     in
     rec {
       # Naersk is not a package, not an app, not a module... It's just a Library


### PR DESCRIPTION
This adds support for the new Apple Silicon processors (aarch64-darwin) which are used in Macbook M1. 
We successfully use this in our project https://github.com/yaxitech/ragenix.