### PR TITLE
Fix doDoc

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -343,7 +343,7 @@ let
       # Remove references to the source derivation to reduce closure size
             match='<meta name="description" content="Source to the Rust file `${builtins.storeDir}[^`]*`.">'
       replacement='<meta name="description" content="Source to the Rust file removed to reduce Nix closure size.">'
-      find target/doc ''${CARGO_BUILD_TARGET:+target/$CARGO_BUILD_TARGET/doc} -name "*\.rs\.html" -exec sed -i "s|$match|$replacement|" {} +
+      find out/doc ''${CARGO_BUILD_TARGET:+target/$CARGO_BUILD_TARGET/doc} -name "*\.rs\.html" -exec sed -i "s|$match|$replacement|" {} +
     ''}
 
       runHook postDoc
@@ -417,7 +417,7 @@ let
         ${lib.optionalString (doDoc && copyDocsToSeparateOutput) ''
         export SOURCE_DATE_EPOCH=1
 
-        cp -r target/doc $doc
+        cp -r out/doc $doc
         if [[ -n "$CARGO_BUILD_TARGET" && -d "target/$CARGO_BUILD_TARGET/doc" ]]; then
           cp -r target/$CARGO_BUILD_TARGET/doc/. $doc/
         fi


### PR DESCRIPTION
Somewhere since commit e09c320446c5c2516d430803f7b19f5833781337, naersk is unable to handle `doDoc`. It seems the code around the cargo doc invocation assumes that documentation appears in target/doc, while it is actually written to out/doc now.

If you need a tiny test case, I have the old working and current failing versions of naersk ready to try [here](https://github.com/blitz/naersk-doc-bug-example).

I've seen that there is actually a test for `doDoc` but the pipeline is red since June. I could help with fixing this, if someone has some pointers what to actually fix. :)