### PR TITLE
Fix copying cargo artifacts from deps

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -240,7 +240,6 @@ let
       # threads as there are cores. This is often too much parallelism so we
       # reduce it to $NIX_BUILD_CORES if not specified by the caller.
       export RUST_TEST_THREADS="''${RUST_TEST_THREADS:-$NIX_BUILD_CORES}"
-      export CARGO_TARGET_DIR="out"
 
       log "cargo_version (read): $cargo_version"
       log "cargo_message_format (set): $cargo_message_format"
@@ -369,7 +368,7 @@ let
           done < <(jq -cMr "$cargo_bins_jq_filter" <"$cargo_build_output_json")
         else
           log "$cargo_build_output_json: file wasn't written, using less reliable copying method"
-          find out -type f -executable \
+          find target -type f -executable \
             -not -name '*.so' -a -not -name '*.dylib' \
             -exec cp {} $out/bin \;
         fi
@@ -390,7 +389,7 @@ let
           done < <(jq -cMr "$cargo_libs_jq_filter" <"$cargo_build_output_json")
         else
           log "$cargo_build_output_json: file wasn't written, using less reliable copying method"
-          find out -type f \
+          find target -type f \
             -name '*.so' -or -name '*.dylib' -or -name '*.a' \
             -exec cp {} $out/lib \;
         fi


### PR DESCRIPTION
* Previously the CARGO_TARGET_DIR environment was set to the `out`
  directory which resulted in cargo placing all of its artifacts there
  instead of the default `target` directory
* Later on, the build scripts would then copy the (empty) `target`
  directory to `$out` resulting in cargo rebuilding the entire
  dependency tree from scratch whenever the top level crate's source was
  changed
* Now we omit the CARGO_TARGET_DIR environment variable and inspect the
  `target` directory for any binaries instead of the `out` directory

Fixes #202 