### PR TITLE
README and templates cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Naersk
 
-[![GitHub Actions](https://github.com/nmattia/naersk/workflows/test/badge.svg?branch=master)](https://github.com/nmattia/naersk/actions)
+[![GitHub Actions](https://github.com/nix-community/naersk/workflows/test/badge.svg?branch=master)](https://github.com/nix-community/naersk/actions)
 
 Nix support for building [cargo] crates.
 
@@ -13,7 +13,7 @@ Nix support for building [cargo] crates.
 Use [niv]:
 
 ``` shell
-$ niv add nmattia/naersk
+$ niv add nix-community/naersk
 ```
 
 And then
@@ -102,14 +102,14 @@ naersk.buildPackage ./my-package
 ```
 
 [cargo]: https://crates.io/
-[niv]: https://github.com/nmattia/niv
+[niv]: https://github.com/nix-community/niv
 
 ## Using with Nix Flakes
 
 Initialize flakes within your repo by running:
 
 ``` bash
-nix flake init -t github:nmattia/naersk
+nix flake init -t github:nix-community/naersk
 nix flake lock
 ```
 
@@ -119,7 +119,7 @@ Alternatively, copy this `flake.nix` into your repo.
 {
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:nix-community/naersk";
   };
 
   outputs = { self, nixpkgs, utils, naersk }:
@@ -155,7 +155,7 @@ available in nixpkgs, you can use mozilla's nixpkgs overlay in your flake.
 {
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:nix-community/naersk";
     mozillapkgs = {
       url = "github:mozilla/nixpkgs-mozilla";
       flake = false;

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -1,6 +1,6 @@
 # Naersk
 
-[![GitHub Actions](https://github.com/nmattia/naersk/workflows/test/badge.svg?branch=master)](https://github.com/nmattia/naersk/actions)
+[![GitHub Actions](https://github.com/nix-community/naersk/workflows/test/badge.svg?branch=master)](https://github.com/nix-community/naersk/actions)
 
 Nix support for building [cargo] crates.
 
@@ -13,7 +13,7 @@ Nix support for building [cargo] crates.
 Use [niv]:
 
 ``` shell
-$ niv add nmattia/naersk
+$ niv add nix-community/naersk
 ```
 
 And then
@@ -78,7 +78,7 @@ naersk.buildPackage ./my-package
 Initialize flakes within your repo by running:
 
 ``` bash
-nix flake init -t github:nmattia/naersk
+nix flake init -t github:nix-community/naersk
 nix flake lock
 ```
 
@@ -88,7 +88,7 @@ Alternatively, copy this `flake.nix` into your repo.
 {
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:nix-community/naersk";
   };
 
   outputs = { self, nixpkgs, utils, naersk }:
@@ -124,7 +124,7 @@ available in nixpkgs, you can use mozilla's nixpkgs overlay in your flake.
 {
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:nix-community/naersk";
     mozillapkgs = {
       url = "github:mozilla/nixpkgs-mozilla";
       flake = false;

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
     naersk = {
-      url = github:nmattia/naersk;
+      url = github:nix-community/naersk;
       inputs.nixpkgs.follows = "nixpkgs";
     };
     fenix = {

--- a/examples/hello-world/flake.nix
+++ b/examples/hello-world/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:nix-community/naersk";
   };
 
   outputs = { self, nixpkgs, flake-utils, naersk }:

--- a/examples/multi-target/flake.nix
+++ b/examples/multi-target/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
     naersk = {
-      url = github:nmattia/naersk;
+      url = github:nix-community/naersk;
       inputs.nixpkgs.follows = "nixpkgs";
     };
     fenix = {

--- a/examples/static-musl/flake.nix
+++ b/examples/static-musl/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
     naersk = {
-      url = github:nmattia/naersk;
+      url = github:nix-community/naersk;
       inputs.nixpkgs.follows = "nixpkgs";
     };
     fenix = {


### PR DESCRIPTION
Replace nmattia with nix-community.
The templates should contain a nix-community not nmattia reference.

