### PR TITLE
tomlDependencies: pass allRefs=true when fetching a `rev`

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -148,6 +148,7 @@ rec
                     url = val.git;
                   } // lib.optionalAttrs (val ? rev) {
                     rev = val.rev;
+                    allRefs = true;
                   } // lib.optionalAttrs (val ? branch) {
                     ref = val.branch;
                   } // lib.optionalAttrs (val ? tag) {


### PR DESCRIPTION
this allows us to avoid issues when the default branch is not named
`master`.

I believe this should fix the issues described in:
https://github.com/nix-community/naersk/issues/149
https://github.com/nix-community/naersk/pull/140

using this change seems to fix this error I was seeing:
```
fetching Git repository 'https://github.com/sacredcapital/rep_lang.git'fatal: couldn't find remote ref refs/heads/master
error: program 'git' failed with exit code 128
```
on a repo which had only a `main` branch, and no `master` branch. of note, I was able to work around the issue by creating a dummy `master` branch, but still using the rev on the `main` branch.

using this PR seems to enable a successful build, without requiring the dummy `master` branch which was not actually used.

I reproduced the successful build on multiple machines. however I cannot
be full certain that it works in all cases.

additionally, it seems possible that `allRefs = true` causes annoying
extra fetching which might be noticeable for repos with many refs...