### PR TITLE
Better error missing cargo lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docparse/target
+target
 /flake.lock
 result*

--- a/config.nix
+++ b/config.nix
@@ -356,7 +356,7 @@ let
       if builtins.pathExists cargolock-file then
         readTOML (cargolock-file)
       else 
-        throw "Naersk requires Cargo.lock to be available in root. Check that it is not in .gitignore when using git to filer (which flakes does)";
+        throw "Naersk requires Cargo.lock to be available in root. Check that it is not in .gitignore and stage it when using git to filer (which flakes does)";
 
     packageName =
       if ! isNull attrs.name

--- a/config.nix
+++ b/config.nix
@@ -356,7 +356,7 @@ let
       if builtins.pathExists cargolock-file then
         readTOML (cargolock-file)
       else 
-        throw "Naersk requires Cargo.lock to be available in root. Check that it is not in .gitignore and stage it when using git to filer (which flakes does)";
+        throw "Naersk requires Cargo.lock to be available in root. Check that it is not in .gitignore and stage it when using git to filter sources (which flakes does)";
 
     packageName =
       if ! isNull attrs.name

--- a/config.nix
+++ b/config.nix
@@ -349,7 +349,14 @@ let
     toplevelCargotoml = readTOML (root + "/Cargo.toml");
 
     # The cargo lock
-    cargolock = readTOML (root + "/Cargo.lock");
+    cargolock = 
+      let
+        cargolock-file = root + "/Cargo.lock";
+      in
+      if builtins.pathExists cargolock-file then
+        readTOML (cargolock-file)
+      else 
+        throw "Naersk requires Cargo.lock to be available in root. Check that it is not in .gitignore when using git to filer (which flakes does)";
 
     packageName =
       if ! isNull attrs.name


### PR DESCRIPTION
This will `throw` a more explanatory error message when Cargo.lock is missing form root.