### PR TITLE
Correctly fetch git tags

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -151,7 +151,7 @@ rec
                   } // lib.optionalAttrs (val ? branch) {
                     ref = val.branch;
                   } // lib.optionalAttrs (val ? tag) {
-                    ref = val.tag;
+                    ref = "refs/tags/${val.tag}";
                   });
                 }
             ) cargotoml.dependencies or { });


### PR DESCRIPTION
Without this change you'd get errors like this when adding a
`git`-dependency to a `Cargo.toml` which is pinned to a tag:

    fetching Git repository 'git://github.com/ma27/nixpkgs-fmt'fatal: couldn't find remote ref refs/heads/v1.2.0-rnix-0.10
    error: program 'git' failed with exit code 128