### PR TITLE
Support different `lib.crate-type`

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -174,7 +174,7 @@ rec
             attrs =
               # Since we pretend everything is a lib, we remove any mentions
               # of binaries
-              removeAttrs cargotoml [ "bin" "example" "lib" "test" "bench" "default-run" ]
+              removeAttrs cargotoml [ "bin" "example" "test" "bench" "default-run" ]
                 // lib.optionalAttrs (builtins.hasAttr "package" cargotoml) ({ package = removeAttrs cargotoml.package [ "default-run" ] ; })
                 ;
           in
@@ -209,7 +209,11 @@ rec
                 pushd $out/$member > /dev/null
                 mkdir -p src
                 # Avoid accidentally pulling `std` for no-std crates.
-                echo '#![no_std]' >src/lib.rs
+                cat <<EOF >src/lib.rs
+                #![no_std]
+                #[panic_handler]
+                fn panic(_info: &core::panic::PanicInfo) -> ! { loop {} }
+            EOF
                 # pretend there's a `build.rs`, otherwise cargo doesn't build
                 # the `[build-dependencies]`. Custom locations of build scripts
                 # aren't an issue because we strip the `build` field in


### PR DESCRIPTION
This is particularly important for the case of WASM binaries, which are necessarily compiled with `crate-type=cdylib`. Without this, when compiling for `CARGO_BUILD_TARGET=wasm32-unknown-unknown`, the `-deps` derivation strips the `[lib]` section of the `Cargo.toml`, so only `lib*.d` and `lib*.rlib` files artifacts are generated under `target/`. Then when the main derivation is compiled, the `[lib]` section is not stripped, so it must recompile all the dependencies again for `cdylib` in order to generate a wasm binary.