### PR TITLE
fix: use `!=` instead of `-ne` for string comparison in `[ ... ]`

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -150,7 +150,7 @@ let
             | grep -oP '(?<=").+(?=")' \
             || true)
 
-          if [ "$name" -ne "$pname" ]; then
+          if [ "$name" != "$pname" ]; then
             continue
           fi
 


### PR DESCRIPTION
Fixes the non-deterministic package mix-up that occurs when the source repository of a git dependency contains multiple packages.

Without this fix, [`github:yvt/nix-rustc_codegen_gcc/555c6e191ff11eb7392d1835caba9b4fbc2c6d48#librustc_codegen_gcc`](https://github.com/yvt/nix-rustc_codegen_gcc/commit/555c6e191ff11eb7392d1835caba9b4fbc2c6d48) could realize `git-deps` in two different ways, one of which is invalid and causes [a build failure in CI](https://github.com/yvt/nix-rustc_codegen_gcc/runs/6637230150?check_suite_focus=true).

Before (GH Actions, invalid):

```
$ head /nix/store/0670wrjrqfxpkx6c6wk72ji8w4sir964-git-deps/gccjit_sys-0.0.1-6c2af0cf733a26740f01a7c679afc20431165a54/Cargo.toml
[package]
name = "square_function"
version = "0.0.1"
authors = ["Sean Gillespie <sean.william.g@gmail.com>"]

[dependencies.gccjit]
path = "../.."
```

Before (local build):

```
$ head /nix/store/0670wrjrqfxpkx6c6wk72ji8w4sir964-git-deps/gccjit_sys-0.0.1-6c2af0cf733a26740f01a7c679afc20431165a54/Cargo.toml
[package]
name = "gccjit_sys"
version = "0.0.1"
authors = ["Sean Gillespie <sean.william.g@gmail.com>"]
#links = "gccjit"
description = "Raw bindings to libgccjit. Companion to the gccjit crate."
keywords = ["compiler", "jit", "gcc"]
license = "GPL-3.0"
repository = "https://github.com/swgillespie/gccjit.rs"
```

After:

```
$ head /nix/store/gn27p044b2jq3kai1p58wiqg9wrymz65-git-deps/gccjit_sys-0.0.1-6c2af0cf733a26740f01a7c679afc20431165a54/Cargo.toml
[package]
name = "gccjit_sys"
version = "0.0.1"
authors = ["Sean Gillespie <sean.william.g@gmail.com>"]
#links = "gccjit"
description = "Raw bindings to libgccjit. Companion to the gccjit crate."
keywords = ["compiler", "jit", "gcc"]
license = "GPL-3.0"
repository = "https://github.com/swgillespie/gccjit.rs"
```