### PR TITLE
force fetchGit allRefs when a dependency is specified with "rev"

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -111,7 +111,7 @@ rec
           ref = lock.branch;
         } // lib.optionalAttrs (lock ? tag) {
           ref = lock.tag;
-        } // lib.optionalAttrs (gitAllRefs || lock ? rev) {
+        } // lib.optionalAttrs ((lib.versionAtLeast builtins.nixVersion "2.4") && (gitAllRefs || lock ? rev)) {
           allRefs = true;
         } // lib.optionalAttrs gitSubmodules {
           submodules = true;

--- a/lib.nix
+++ b/lib.nix
@@ -111,7 +111,7 @@ rec
           ref = lock.branch;
         } // lib.optionalAttrs (lock ? tag) {
           ref = lock.tag;
-        } // lib.optionalAttrs gitAllRefs {
+        } // lib.optionalAttrs (gitAllRefs || lock ? rev) {
           allRefs = true;
         } // lib.optionalAttrs gitSubmodules {
           submodules = true;


### PR DESCRIPTION
The usage of git "rev" dependencies in Cargo implies that the rev
will be found regardless of ref.  This is currently not true in naersk;
the following dependency fails:

usbfs = {git = "https://github.com/goertzenator/usbfs-rs", rev = "7c35b46e41ad76f838cd99b493f9337f475b5b70"}

