### PR TITLE
Disambiguate branch/tag refs passed to fetchGit

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -108,9 +108,9 @@ rec
           url = lock.url;
           rev = lock.revision;
         } // lib.optionalAttrs (lock ? branch) {
-          ref = lock.branch;
+          ref = "refs/heads/${lock.branch}";
         } // lib.optionalAttrs (lock ? tag) {
-          ref = lock.tag;
+          ref = "refs/tags/${lock.tag}";
         } // lib.optionalAttrs ((lib.versionAtLeast builtins.nixVersion "2.4") && (gitAllRefs || lock ? rev)) {
           allRefs = true;
         } // lib.optionalAttrs gitSubmodules {


### PR DESCRIPTION
# Overview

Starting from a clean Nix fetcher cache, Naersk incorrectly handles dependencies from a `Cargo.lock` when they come from a `git+ssh://` URL at a specific tag, assuming no branch of the same name exists.

This usually shows up as an error like
```
fetching Git repository 'ssh://git@some.private.git.server/repo.git' fatal: couldn't find remote ref refs/heads/some_tag
```
indicating that `builtins.fetchGit` is attempting to fetch `refs/heads/some_tag` instead of `refs/tags/some_tag` as expected.

# Proposed solution

This is easy to fix: if we need to use `builtins.fetchGit` to download sources, use a more explicit, unambiguous `ref` argument depending on whether a `branch` or `tag` was specified for that entry in `Cargo.lock`.

# Reproducing this issue

Nix's impure fetcher cache can conceal this problem, at least with my version of Nix (2.9.1). If you're attempting to reproduce it, start with a clean fetcher cache:

```shell
rm -rf ~/.cache/nix/fetcher-cache* ~/.cache/nix/git*
```

Some other environment details, in case they're pertinent:
* Nix 2.9.1
* git 2.25.1
* Non-NixOS Linux (Ubuntu 20.04 LTS)
* The `Cargo.lock` where we first noticed this problem has `version = 3`

If needed, I'd be happy to throw together an example project demonstrating the issue.