### PR TITLE
Support incremental builds with CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,31 @@ naersk.buildPackage {
 }
 ```
 
+### Using CMake
+
+If your application uses CMake, the build process might fail, saying:
+
+```
+CMake Error: The current CMakeCache.txt directory ... is different than the directory ... where CMakeCache.txt was created.
+```
+
+You can fix this problem by removing stale `CMakeCache.txt` files before the
+build:
+
+``` nix
+naersk.buildPackage {
+  # ...
+  
+  preBuild = ''
+    find \
+        -name CMakeCache.txt \
+        -exec rm {} \;
+  '';
+}
+```
+
+([context](https://github.com/nix-community/naersk/pull/288))
+
 ### Using OpenSSL
 
 If your application uses OpenSSL (making the build process fail), try:

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -249,6 +249,31 @@ naersk.buildPackage {
 }
 ```
 
+### Using CMake
+
+If your application uses CMake, the build process might fail, saying:
+
+```
+CMake Error: The current CMakeCache.txt directory ... is different than the directory ... where CMakeCache.txt was created.
+```
+
+You can fix this problem by removing stale `CMakeCache.txt` files before the
+build:
+
+``` nix
+naersk.buildPackage {
+  # ...
+  
+  preBuild = ''
+    find \
+        -name CMakeCache.txt \
+        -exec rm {} \;
+  '';
+}
+```
+
+([context](https://github.com/nix-community/naersk/pull/288))
+
 ### Using OpenSSL
 
 If your application uses OpenSSL (making the build process fail), try:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/ninegua/agent-rs/archive/4a22e590516bc79ec3c75a320f7941e7762ea098.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "fenix": {
+        "branch": "main",
+        "description": "Rust toolchains and rust-analyzer nightly for Nix [maintainer=@figsoda]",
+        "homepage": "",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "06776a448cfdee8ed146305369c1810cd7c82799",
+        "sha256": "15z2mcrgzj9322xndk1xs29m23rdkfzbg2b0w0hva489rnq4mnc3",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/fenix/archive/06776a448cfdee8ed146305369c1810cd7c82799.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "lorri": {
         "branch": "master",
         "description": "foo",

--- a/test/slow/agent-rs/default.nix
+++ b/test/slow/agent-rs/default.nix
@@ -2,7 +2,6 @@
 
 naersk.buildPackage {
   src = sources.agent-rs;
-  doCheck = true;
 
   buildInputs = [
     pkgs.openssl


### PR DESCRIPTION
When CMake builds a project, it generates a file called `CMakeCache.txt` that contains - among others - a dump of environmental variables.

This file is generated both for the deps-only- and the main- derivation, and if env-vars happen to differ between both¹, CMake will refuse to compile the latter derivation, saying:

```
CMake Error: The current CMakeCache.txt directory ... is different than the directory ... where CMakeCache.txt was created.
```

Solving this problem is easy - one just has to remove `CMakeCache.txt` to let CMake regenerate it.

Note that the original bug report (linked below) suggests to use `sed`, but that doesn't work on Darwin which uses a different convention for temporary paths - compare error messages for the failing derivations:

... on Linux:

```
CMake Error: The current CMakeCache.txt directory /build/source/target/release/build/oqs-sys-a19e222d9ef825d3/out/build/CMakeCache.txt is different than the directory /build/dummy-src/target/release/build/oqs-sys-a19e222d9ef825d3/out/build where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt
```

... and on Darwin:

```
CMake Error: The current CMakeCache.txt directory /tmp/nix-build-app-0.1.0.drv-5/source/target/release/build/oqs-sys-4b5e25b1671aa1e5/out/build/CMakeCache.txt is different than the directory /tmp/nix-build-app-deps-0.1.0.drv-0/source/target/release/build/oqs-sys-4b5e25b1671aa1e5/out/build where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt
```

As for the implementation, since two-step builds are a Naersk-specific construct, I think solving this transparently on Naersk's side instead of just adding a tip into README.md is the better approach here, since it keeps Naersk plug-and-play'able.

Closes https://github.com/nix-community/naersk/issues/285.

¹ which is not that difficult, e.g. that's how `pkgs.rustPlatform.bindgenHook` behaves