### PR TITLE
Add descriptions so nix flake check passes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,24 +15,28 @@
 
       templates = {
         hello-world = {
+          description = "A simple and straight-forward 'hello world' Rust program.";
           path =
             builtins.filterSource (path: type: baseNameOf path == "flake.nix")
               ./examples/hello-world;
         };
 
         cross-windows = {
+          description = "Pre-configured for cross-compiling to Windows.";
           path =
             builtins.filterSource (path: type: baseNameOf path == "flake.nix")
               ./examples/cross-windows;
         };
 
         static-musl = {
+          description = "Pre-configured for statically linked binaries for Linux with musl.";
           path =
             builtins.filterSource (path: type: baseNameOf path == "flake.nix")
               ./examples/static-musl;
         };
 
         multi-target = {
+          description = "A Rust project with multiple crates and build targets.";
           path =
             builtins.filterSource (path: type: baseNameOf path == "flake.nix")
               ./examples/multi-target;


### PR DESCRIPTION
Otherwise, `nix flake check` fails:

```
grahamc@Grahams-Air naersk % nix flake show --no-write-lock-file
warning: not writing modified lock file of flake 'git+file:///Users/grahamc/projects/naersk':
• Added input 'nixpkgs':
    'github:NixOS/nixpkgs/12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d' (2023-10-15)
git+file:///Users/grahamc/projects/naersk?ref=refs/heads/master&rev=3f976d822b7b37fc6fb8e6f157c2dd05e7e94e89
error: attribute 'defaultTemplate.description' does not exist
```