### PR TITLE
Fixes nix-community/naersk#224

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -76,8 +76,8 @@ let
       { inherit lib writeText remarshal runCommandLocal formats; };
 
   drvAttrs = {
-    name = "${pname}-${version}";
     inherit
+      pname
       src
       version
       remapPathPrefix


### PR DESCRIPTION
`name` will still be defined by mkDerivation when `pname` and `version` are defined and this is actually preferred according to RFC0035.

By defining `pname`, `flake-utils.lib.mkApp` will prefer this over `name` when calling the executable.