### PR TITLE
Fix .cargo-home/config warning on nightly, bump probe-rs

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -244,6 +244,7 @@ let
       mkdir -p $CARGO_HOME
 
       cp "$cargoconfig" $CARGO_HOME/config.toml
+      # symlink for backwards compatibility with older cargo
       ln -s ./config.toml $CARGO_HOME/config
 
       runHook postConfigure

--- a/build.nix
+++ b/build.nix
@@ -243,7 +243,8 @@ let
       export CARGO_HOME=''${CARGO_HOME:-$PWD/.cargo-home}
       mkdir -p $CARGO_HOME
 
-      cp "$cargoconfig" $CARGO_HOME/config
+      cp "$cargoconfig" $CARGO_HOME/config.toml
+      ln -s ./config.toml $CARGO_HOME/config
 
       runHook postConfigure
     '';

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "https://probe.rs",
         "owner": "probe-rs",
         "repo": "probe-rs",
-        "rev": "51fa324aef9f7c413988a3d18052b1bbc278a4c5",
-        "sha256": "0zb9s80hsz83ngjngs9cllp7gf8xq9jz0m3lwdhf08x3cp3bj6fd",
+        "rev": "c651f263751b370473f61addc58ccf93eb054374",
+        "sha256": "1n2w2gz68wf2961mjhdgi6v3jhprygkri36gr9c4kd4gykadpzdw",
         "type": "tarball",
-        "url": "https://github.com/probe-rs/probe-rs/archive/51fa324aef9f7c413988a3d18052b1bbc278a4c5.tar.gz",
+        "url": "https://github.com/probe-rs/probe-rs/archive/c651f263751b370473f61addc58ccf93eb054374.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ripgrep-all": {

--- a/test/slow/probe-rs/default.nix
+++ b/test/slow/probe-rs/default.nix
@@ -4,8 +4,8 @@ let
 
   toolchain = (fenix.toolchainOf {
     channel = "nightly";
-    date = "2023-07-01";
-    sha256 = "sha256-pWd4tAHP4QWGC3CKWZzDjzYANxATC6CGRmKuP2ZZv5k=";
+    date = "2024-04-12";
+    sha256 = "sha256-nOsrWb08M6PTE3qXqaiCyKBy7Shk2YTvALYaIvNWa1s=";
   }).toolchain;
 
   naersk = pkgs.callPackage ../../../default.nix {


### PR DESCRIPTION
This PR fixes the nightly warning
```
warning: `/build/probe-rs-src/.cargo-home/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
```

Also bumps the probe-rs sources and the rust nightly version used for testing it