### PR TITLE
Drop macOS SDKs that follow "the old way"

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -58,7 +58,6 @@
 , lib
 , rsync
 , jq
-, darwin
 , writeText
 , runCommandLocal
 , remarshal
@@ -137,12 +136,7 @@ let
       ++ lib.optionals (mode == "clippy") [clippy]
       ++ neededCrateSpecificOverrides.nativeBuildInputs;
 
-    buildInputs = lib.optionals stdenv.isDarwin [
-      darwin.Security
-      darwin.apple_sdk.frameworks.CoreServices
-      darwin.cf-private
-      darwin.libiconv
-    ] ++ buildInputs
+    buildInputs = buildInputs
       ++ neededCrateSpecificOverrides.buildInputs;
 
     inherit builtDependencies;

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
 { cargo
-, darwin
 , fetchurl
 , jq
 , lib


### PR DESCRIPTION
Nixpkgs now has much more reasonable handling of macOS SDKs, and this old default is not generally needed  for builds anymore.

I think having these SDKs in the inputs is a bit of a nuisance now, since it means there are mixed framework versions in the closure.

See: https://discourse.nixos.org/t/on-the-future-of-darwin-sdks-or-how-you-can-stop-worrying-and-put-the-sdk-in-build-inputs/50574
See: https://github.com/NixOS/nixpkgs/pull/346043

Note: this is also tagged at https://github.com/DeterminateSystems/naersk/releases/tag/apple-sdks for use.