### PR TITLE
don't use indirect nixpkgs references

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "Build Rust projects with ease. No configuration, no code generation; IFD and sandbox friendly.";
 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
+
   outputs = { self, nixpkgs }:
     let
       forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" "aarch64-darwin" ];


### PR DESCRIPTION
Those are deprecated in Nix:

https://github.com/NixOS/nix/pull/12068