### PR TITLE
Fix jq parse error when cargo test runs a failing test

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -258,6 +258,8 @@ let
       logRun ${cargoCommand} || cargo_ec="$?"
 
       if [ "$cargo_ec" -ne "0" ]; then
+      # we allow non-json (with jq -R, try, catch) as tests might also produce output
+      # https://github.com/nix-community/naersk/issues/353
         cat "$cargo_build_output_json" | jq -cMrR '. as $line | try (fromjson | select(.message.rendered != null) | .message.rendered) catch $line'
         log "cargo returned with exit code $cargo_ec, exiting"
         exit "$cargo_ec"

--- a/build.nix
+++ b/build.nix
@@ -258,7 +258,7 @@ let
       logRun ${cargoCommand} || cargo_ec="$?"
 
       if [ "$cargo_ec" -ne "0" ]; then
-        cat "$cargo_build_output_json" | jq -cMr 'select(.message.rendered != null) | .message.rendered'
+        cat "$cargo_build_output_json" | jq -cMrR '. as $line | try (fromjson | select(.message.rendered != null) | .message.rendered) catch $line'
         log "cargo returned with exit code $cargo_ec, exiting"
         exit "$cargo_ec"
       fi


### PR DESCRIPTION
Relay non-JSON lines in cargo output

Forward both JSON log messages from `cargo test` and non-JSON messagse from the test binary itself.

(Note: the test binaries do have a `--format` option, but the "json" format is unstable and so can only be used by nightly `cargo`)

Fixes: https://github.com/nix-community/naersk/issues/353